### PR TITLE
Avoid reported problem of duplicate xmnls declarations at start of doc. ...

### DIFF
--- a/src/org/marc4j/MarcXmlWriter.java
+++ b/src/org/marc4j/MarcXmlWriter.java
@@ -19,13 +19,11 @@
  */
 package org.marc4j;
 
-import java.io.BufferedWriter;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.io.UnsupportedEncodingException;
-import java.io.Writer;
-import java.util.Iterator;
+import org.marc4j.converter.CharConverter;
+import org.marc4j.marc.*;
+import org.marc4j.util.Normalizer;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.AttributesImpl;
 
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Result;
@@ -35,16 +33,8 @@ import javax.xml.transform.sax.SAXTransformerFactory;
 import javax.xml.transform.sax.TransformerHandler;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
-
-import org.marc4j.converter.CharConverter;
-import org.marc4j.marc.ControlField;
-import org.marc4j.marc.DataField;
-import org.marc4j.marc.Leader;
-import org.marc4j.marc.Record;
-import org.marc4j.marc.Subfield;
-import org.marc4j.util.Normalizer;
-import org.xml.sax.SAXException;
-import org.xml.sax.helpers.AttributesImpl;
+import java.io.*;
+import java.util.Iterator;
 
 
 /**
@@ -320,6 +310,7 @@ public class MarcXmlWriter implements MarcWriter {
     public void close() {
     	writeEndDocument();
     	try {
+            writer.write("\n");
     		writer.close();
     	} catch (IOException e) {
     		throw new MarcException(e.getMessage(), e);
@@ -402,11 +393,6 @@ public class MarcXmlWriter implements MarcWriter {
         try {
             AttributesImpl atts = new AttributesImpl();
             handler.startDocument();
-            // The next line duplicates the namespace declaration for Marc XML
-            // handler.startPrefixMapping("", Constants.MARCXML_NS_URI);
-            // add namespace declaration using attribute - need better solution
-            atts.addAttribute(Constants.MARCXML_NS_URI, "xmlns", "xmlns",
-                              "CDATA", Constants.MARCXML_NS_URI);            
             handler.startElement(Constants.MARCXML_NS_URI, COLLECTION, COLLECTION, atts);
         } catch (SAXException e) {
             throw new MarcException(


### PR DESCRIPTION
... Add newline at end of doc.  No changes in the middle

Fixes Issue #19 ( at least, it does not break the unit test)
