### PR TITLE
Support custom encoding different from UTF-8, MARC8, ISO-8859-1 (CP866 in particular)

### DIFF
--- a/src/org/marc4j/MarcStreamReader.java
+++ b/src/org/marc4j/MarcStreamReader.java
@@ -414,7 +414,14 @@ public class MarcStreamReader implements MarcReader {
                 throw new MarcException("unsupported encoding", e);
             }
         }
+        else if (override) {
+            try {
+                dataElement = new String(bytes, encoding);
+            }
+            catch (UnsupportedEncodingException e) {
+                throw new MarcException("unsupported encoding", e);
+            }
+        }
         return dataElement;
     }
-    
 }


### PR DESCRIPTION
If i explicitly define custom encoding, for example CP866 all data fields will be null.
