### PR TITLE
added subfield selector patterns to DataField

### DIFF
--- a/src/org/marc4j/marc/DataField.java
+++ b/src/org/marc4j/marc/DataField.java
@@ -24,6 +24,21 @@ import java.util.List;
 /**
  * Represents a data field in a MARC record.
  * 
+ * <h3>Subfield Selectors</h3>
+ * <p>
+ * The {@code getSubfields*} methods take a subfield selector string. 
+ * This string can be a simple list of subfield letters,
+ * or a bracket-enslosed character class expression, as in regular expressions.
+ * <p>
+ * For example:
+ * <ul>
+ * <li>
+ * {@code abc} well match any of subfields {@literal a}, {@literal b} or {@literal c}.
+ * <li>
+ * {@code [a-cf-g]} will match any of {@literal a-c} or {@literal f-g}, but not {@literal d}.
+ * </ul>
+ * <p>
+ * 
  * @author Bas Peters
  */
 public interface DataField extends VariableField {
@@ -65,15 +80,37 @@ public interface DataField extends VariableField {
 	 */
 	public List<Subfield> getSubfields();
 
-	/**
-	 * Returns the list of <code>Subfield</code> objects for the goven
-	 * subfield code.
-	 * 
-	 * @param code
-	 *            the subfield code
-	 * @return List - the list of <code>Subfield</code> objects
-	 */
-	public List<Subfield> getSubfields(char code);
+        /**
+         * Returns the list of <code>Subfield</code> objects for the given
+         * subfield code.
+         * 
+         * @param code
+         *            the subfield code
+         * @return List - the list of <code>Subfield</code> objects
+         */
+        public List<Subfield> getSubfields(char code);
+
+        /**
+         * Returns the list of <code>Subfield</code> objects that match the
+         * subfield spec.
+         * 
+         * @param sfSpec
+         *            the subfield spec
+         * @return List - the list of <code>Subfield</code> objects
+         */
+        public List<Subfield> getSubfields(String sfSpec);
+        
+        /**
+         * Get the data from the specified subfields.
+         * This is essentially a map/reduce over the subfields.
+         * <p>
+         * Currently, the subfield spec must specify each subfield needed, there is no covenient shorthand for a range.
+         * 
+         * @param df  datafield
+         * @param sfSpec  subfield spec
+         * @return requested subfield data, null if no subfields are matched
+         */
+        public String getSubfieldsAsString(String sfSpec);
 
 	/**
 	 * Returns the first <code>Subfield</code> with the given code.

--- a/test/src/org/marc4j/test/DataFieldTest.java
+++ b/test/src/org/marc4j/test/DataFieldTest.java
@@ -1,5 +1,7 @@
 package org.marc4j.test;
 
+import java.util.List;
+
 import org.junit.Test;
 import org.marc4j.marc.DataField;
 import org.marc4j.marc.MarcFactory;
@@ -37,6 +39,33 @@ public class DataFieldTest  {
         assertEquals(2, df.getSubfields().size());
         assertEquals('a', s.getCode());
     }
+
+    @Test
+    public void testGetSubfields() {
+        DataField df = factory.newDataField("245", '1', '0');
+        Subfield sf1 = factory.newSubfield('a', "Summerland");
+        Subfield sf2 = factory.newSubfield('c', "Michael Chabon");
+        df.addSubfield(sf2);
+        df.addSubfield(0, sf1);
+        List<Subfield> sList = (List<Subfield>) df.getSubfields("a");
+        assertEquals(1, sList.size());
+        assertEquals('a', sList.get(0).getCode());
+        
+        List<Subfield> sList2 = (List<Subfield>) df.getSubfields("ac");
+        assertEquals(2, sList2.size());
+        assertEquals('a', sList2.get(0).getCode());
+        assertEquals('c', sList2.get(1).getCode());
+        
+        List<Subfield> sList3 = (List<Subfield>) df.getSubfields("[a-c]");
+        assertEquals(2, sList3.size());
+        assertEquals('a', sList3.get(0).getCode());
+        assertEquals('c', sList3.get(1).getCode());
+        
+        List<Subfield> sList4 = (List<Subfield>) df.getSubfields("[c-e]");
+        assertEquals(1, sList4.size());
+        assertEquals('c', sList4.get(0).getCode());
+    }
+
     @Test
     public void testComparable() throws Exception {
         DataField df1 = factory.newDataField("600", '0', '0');


### PR DESCRIPTION
Here's a proposed patch to add subfield selectors to DataField. It gives support for the kind of subfield notations already used in solrmarc for selecting subfields from data fields:

abc
[a-cm-p]
