### PR TITLE
Fixing threading bug

### DIFF
--- a/src/org/marc4j/MarcXmlParserThread.java
+++ b/src/org/marc4j/MarcXmlParserThread.java
@@ -32,11 +32,11 @@ import org.xml.sax.InputSource;
  */
 public class MarcXmlParserThread extends Thread {
 
-    private RecordStack queue;
+    private final RecordStack queue;
 
-    private InputSource input;
+    private volatile InputSource input;
 
-    private TransformerHandler th = null;
+    private volatile TransformerHandler th;
 
     /**
      * Creates a new instance and registers the <code>RecordQueue</code>.


### PR DESCRIPTION
Hi,

I'm submitting this patch to Marc4J for a threading bug I found in Marc4J.  Using Marc4J version 2.6.3 I was sometimes getting the following stacktrace when reading Marc data:

```
org.marc4j.MarcException: Unable to parse input
        at org.marc4j.MarcXmlParser.parse(MarcXmlParser.java:95)
        at org.marc4j.MarcXmlParser.parse(MarcXmlParser.java:64)
        at org.marc4j.MarcXmlParserThread.run(MarcXmlParserThread.java:115)
Caused by: org.xml.sax.SAXParseException; lineNumber: 1; columnNumber: 1; Premature end of file.
        at com.sun.org.apache.xerces.internal.parsers.AbstractSAXParser.parse(AbstractSAXParser.java:1239)
        at com.sun.org.apache.xerces.internal.jaxp.SAXParserImpl$JAXPSAXParser.parse(SAXParserImpl.java:649)
        at org.marc4j.MarcXmlParser.parse(MarcXmlParser.java:93)
        ... 2 more
```

(Using the latest master branch also caused the same error too)

This only occurs sometimes (maybe 1 in every 5 runs when running in Java 8 on Linux). The problem does not occur when using earlier versions of Java or when using Windows. I have investigated this and discovered it is being caused by a bug in the class MarcXmlParserThread (in the marc4J library). The problem is caused by the member variable "InputSource input" not being declared "volatile". This variable needs to be declared volatile since it will always be set in a different thread (regardless of whether it is set during construction or by the setter), to the thread using it (The thread defined by MarcXmlParserThread).

In addition to this fh should be declared volatile and queue should be declared final, since both these will also always be set in a different thread to the thread which uses them.

(Also removed "th  = null" to prevent double initialization - http://www.javapractices.com/topic/TopicAction.do?Id=14)