### PR TITLE
Fix issue in MarcXmlWriter for 'bad' XML characters.  

### DIFF
--- a/src/org/marc4j/MarcXmlWriter.java
+++ b/src/org/marc4j/MarcXmlWriter.java
@@ -376,10 +376,10 @@ public class MarcXmlWriter implements MarcWriter {
     }
 
     /**
-     * Returns true if this writer will check for non-XML characters and replace them with a form like "&lt;U+xxxx&gt;", 
+     * Returns true if this writer will check for non-XML characters and replace them with a form like "&lt;U+xxxx&gt;",
      * false otherwise.
-     * 
-     * @return boolean - true if this writer checks for (and replaces) non-XML characters, false otherwise. 
+     *
+     * @return boolean - true if this writer checks for (and replaces) non-XML characters, false otherwise.
      */
     public boolean getCheckNonXMLChars() {
         return checkNonXMLChars;
@@ -662,9 +662,9 @@ public class MarcXmlWriter implements MarcWriter {
     }
 
     /**
-     * Iterate through the characters in the dataElement, if any of them are invalid characters 
+     * Iterate through the characters in the dataElement, if any of them are invalid characters
      * or control characters or "discouraged" characters, replace character with a &lt;U+XXXX&gt;
-     * representation of the character. 
+     * representation of the character.
      * @param dataElement - the data value to check for invalid XML characters
      * @return the same string with invalid characters replaced with a &lt;U+XXXX&gt; representation
      */
@@ -673,7 +673,7 @@ public class MarcXmlWriter implements MarcWriter {
         for (final char ch : dataElement.toCharArray()) {
             if (isInvalidXmlChar(ch)) {
                 out.append("<U+");
-                final String hex = "0000" + Integer.toString(ch);
+                final String hex = "0000" + Integer.toString(ch, 16);
                 out.append(hex.substring(hex.length() - 4));
                 out.append('>');
             } else {
@@ -692,8 +692,8 @@ public class MarcXmlWriter implements MarcWriter {
             .compile("[\\uFDD0-\\uFDEF\\x{1FFFE}-\\x{1FFFF}\\x{2FFFE}-\\x{2FFFF}\\x{3FFFE}-\\x{3FFFF}\\x{4FFFE}-\\x{4FFFF}\\x{5FFFE}-\\x{5FFFF}\\x{6FFFE}-\\x{6FFFF}\\x{7FFFE}-\\x{7FFFF}\\x{8FFFE}-\\x{8FFFF}\\x{9FFFE}-\\x{9FFFF}\\x{AFFFE}-\\x{AFFFF}\\x{BFFFE}-\\x{BFFFF}\\x{CFFFE}-\\x{CFFFF}\\x{DFFFE}-\\x{DFFFF}\\x{EFFFE}-\\x{EFFFF}\\x{FFFFE}-\\x{FFFFF}\\x{10FFFE}-\\x{10FFFF}]");
 
     /**
-     * A replacement for the method XmlChar.isInvalid(char ch) found in the 
-     * class com.sun.org.apache.xerces.internal.util.XMLChar;  which, since its an 
+     * A replacement for the method XmlChar.isInvalid(char ch) found in the
+     * class com.sun.org.apache.xerces.internal.util.XMLChar;  which, since its an
      * internal class, apparently shouldn't be used.
      */
     private static boolean isInvalidXmlChar(final char ch) {

--- a/test/src/org/marc4j/test/MarcXmlWriterTest.java
+++ b/test/src/org/marc4j/test/MarcXmlWriterTest.java
@@ -1,14 +1,6 @@
 
 package org.marc4j.test;
 
-import java.io.BufferedReader;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-
-import javax.xml.transform.dom.DOMResult;
-
 import org.custommonkey.xmlunit.XMLTestCase;
 import org.junit.Test;
 import org.marc4j.Constants;
@@ -25,6 +17,13 @@ import org.marc4j.test.utils.TestUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
+
+import javax.xml.transform.dom.DOMResult;
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 
 public class MarcXmlWriterTest extends XMLTestCase {
 
@@ -301,7 +300,7 @@ public class MarcXmlWriterTest extends XMLTestCase {
                 assertTrue(line.contains("code=\"&lt;U+0014&gt;\">&lt;U+0014&gt; 2011035923"));
             } else if (line.contains("9781410442444")) {
                 // subfield delimiter in subfield text
-                assertTrue(line.contains("code=\"&lt;U+0031&gt;\">9781410442444 (hbk.)"));
+                assertTrue(line.contains("code=\"&lt;U+001f&gt;\">9781410442444 (hbk.)"));
             }
         }
         testoutput.close();


### PR DESCRIPTION
Conversion of character to string was done base 10 - should have been base 16 since we want HEX, not DECIMAL values in a ""<U+xxxx>" representation of the bad character.