### PR TITLE
Issue #72: Reporting previous control number if current is not available

### DIFF
--- a/src/org/marc4j/util/RecordIODriver.java
+++ b/src/org/marc4j/util/RecordIODriver.java
@@ -155,6 +155,7 @@ public class RecordIODriver {
             e.printStackTrace();
         }
 
+        String previousControlNumber = "n/a";
         while (reader.hasNext()) {
             String controlNumber = "n/a";
             String location = "after";
@@ -171,9 +172,11 @@ public class RecordIODriver {
                 }
             }
             catch (RuntimeException re) {
-                System.err.println("Exception "+location+" record: "+ controlNumber + " -- " + re.getMessage());
+                System.err.printf("Exception %s record: %s -- %s\n",
+                  location, (location.equals("after") ? previousControlNumber : controlNumber), re.getMessage());
                 re.printStackTrace(System.err);
             }
+            previousControlNumber = controlNumber;
 
         }
         writer.close();


### PR DESCRIPTION
Here is a suggested solution for reporting the previous control number. It generates the following error report:

```
Exception after record: MOKKAZ0006465966   -- Offsets to fields are out of order AND the directory is messed up
org.marc4j.MarcException: Offsets to fields are out of order AND the directory is messed up
	at org.marc4j.MarcPermissiveStreamReader.parseRecord(MarcPermissiveStreamReader.java:814)
	at org.marc4j.MarcPermissiveStreamReader.next(MarcPermissiveStreamReader.java:356)
	at org.marc4j.util.RecordIODriver.main(RecordIODriver.java:164)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.marc4j.util.UtilDriver.invokeCommand(UtilDriver.java:74)
	at org.marc4j.util.UtilDriver.main(UtilDriver.java:54)
```