### PR TITLE
https for repo1.maven.org; Ivy 2.5.0

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -317,7 +317,7 @@
         </jar>
     </target>
 
-    <property name="ivy.install.version" value="2.3.0" />
+    <property name="ivy.install.version" value="2.5.0" />
     <property name="ivy.jar.dir" value="${basedir}/ivy" />
     <property name="ivy.jar.file" value="${ivy.jar.dir}/ivy.jar" />
 
@@ -329,7 +329,7 @@
         <mkdir dir="${ivy.jar.dir}"/>
 
         <echo message="installing ivy..."/>
-        <get src="http://repo1.maven.org/maven2/org/apache/ivy/ivy/${ivy.install.version}/ivy-${ivy.install.version}.jar" dest="${ivy.jar.file}" usetimestamp="true"/>
+        <get src="https://repo1.maven.org/maven2/org/apache/ivy/ivy/${ivy.install.version}/ivy-${ivy.install.version}.jar" dest="${ivy.jar.file}" usetimestamp="true"/>
     </target>
 
     <target name="setup-ivy" depends="download-ivy" description="--> setup ivy" unless="prepared">


### PR DESCRIPTION
Requests to http://repo1.maven.org/maven2/ return a `501 HTTPS Required` status and a body:

    501 HTTPS Required.
    Use https://repo1.maven.org/maven2/
    More information at https://links.sonatype.com/central/501-https-required

Bumping Ivy from 2.3.0 to 2.5.0 changes http to https for dependency download.