### PR TITLE
Add support for NLM call-numbers

### DIFF
--- a/src/org/marc4j/callnum/NlmCallNumber.java
+++ b/src/org/marc4j/callnum/NlmCallNumber.java
@@ -1,0 +1,40 @@
+package org.marc4j.callnum;
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Parses and computes sort keys for National Library of Medicine call numbers.
+ * This class uses the same logic for computing sort keys as {@link LCCallNumber}
+ * but it has changes {@link #isValid()} method.NLM call numbers utilizes schedules QS-QZ and W-WZ
+ */
+public class NlmCallNumber extends LCCallNumber {
+
+  public NlmCallNumber(String rawCallNumber) {
+    super(rawCallNumber);
+  }
+
+  @Override
+  public boolean isValid() {
+    if (this.classLetters == null || this.classLetters.length() < 2 || this.classDigits == null) {
+      return false;
+    } else {
+      char firstChar = this.classLetters.charAt(0);
+      char secondChar = this.classLetters.charAt(1);
+      return firstChar == 'W' || (firstChar == 'Q' && (secondChar >= 'S' && secondChar <= 'Z'));
+    }
+  }
+}

--- a/test/org/marc4j/callnum/NlmCallNumberTest.java
+++ b/test/org/marc4j/callnum/NlmCallNumberTest.java
@@ -1,0 +1,51 @@
+package org.marc4j.callnum;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+
+public class NlmCallNumberTest {
+
+  private static final List<String> validNlmNumbers = Arrays.asList(
+    "QS 11 .GA1 E53 2005",
+    "QS 11 .GA1 F875d 1999",
+    "QS 11 .GA1 Q6 2012",
+    "QS 11 .GI8 P235s 2006",
+    "QS 124 B811m 1875",
+    "QT 104 B736 2003",
+    "QT 104 B736 2009",
+    "WA 102.5 B5315 2018",
+    "WA 102.5 B62 2018",
+    "WB 102.5 B62 2018",
+    "WC 250 M56 2011",
+    "WC 250 M6 2011"
+  );
+
+  private static final List<String> invalidNlmNumbers = Arrays.asList(
+    "QA 11 .GA1 E53 2005",
+    "QB 11 .GA1 F875d 1999",
+    "QC 11 .GA1 Q6 2012",
+    "QD 11 .GI8 P235s 2006",
+    "QG 124 B811m 1875",
+    "W 250 M56 2011",
+    "Z 250 M6 2011"
+  );
+
+  @Test
+  public void isValidNlmNumber() {
+    for (String validNlmNumber : validNlmNumbers) {
+      assertTrue(new NlmCallNumber(validNlmNumber).isValid());
+    }
+  }
+
+  @Test
+  public void isInvalidNlmNumber() {
+    for (String validNlmNumber : invalidNlmNumbers) {
+      assertFalse(new NlmCallNumber(validNlmNumber).isValid());
+    }
+  }
+
+}


### PR DESCRIPTION
NLM call numbers have the same structure as LC call numbers but utilize schedules QS-QZ and W-WZ.
`NlmCallNumber` class was created and extended from `LCCallNumber` with overriden `isValid` method to support NLM call numbers.