### PR TITLE
NLM: Accept W, reject more than 3 class letters

### DIFF
--- a/src/org/marc4j/callnum/NlmCallNumber.java
+++ b/src/org/marc4j/callnum/NlmCallNumber.java
@@ -17,9 +17,10 @@ package org.marc4j.callnum;
  */
 
 /**
- * Parses and computes sort keys for National Library of Medicine call numbers.
+ * Parses and computes sort keys for
+ * <a href="https://classification.nlm.nih.gov/">National Library of Medicine call numbers</a>.
  * This class uses the same logic for computing sort keys as {@link LCCallNumber}
- * but it has changes {@link #isValid()} method.NLM call numbers utilizes schedules QS-QZ and W-WZ
+ * but it has changed {@link #isValid()} method. NLM call numbers utilize schedules QS-QZ and W and WA-WZ.
  */
 public class NlmCallNumber extends LCCallNumber {
 
@@ -29,12 +30,12 @@ public class NlmCallNumber extends LCCallNumber {
 
   @Override
   public boolean isValid() {
-    if (this.classLetters == null || this.classLetters.length() < 2 || this.classDigits == null) {
+    if (this.classLetters == null || this.classLetters.length() > 2 || this.classDigits == null) {
       return false;
-    } else {
-      char firstChar = this.classLetters.charAt(0);
-      char secondChar = this.classLetters.charAt(1);
-      return firstChar == 'W' || (firstChar == 'Q' && (secondChar >= 'S' && secondChar <= 'Z'));
     }
+    if (this.classLetters.startsWith("W")) {
+      return true;
+    }
+    return this.classLetters.compareTo("QS") >= 0 && this.classLetters.compareTo("QZ") <= 0;
   }
 }

--- a/src/org/marc4j/callnum/NlmCallNumber.java
+++ b/src/org/marc4j/callnum/NlmCallNumber.java
@@ -20,7 +20,8 @@ package org.marc4j.callnum;
  * Parses and computes sort keys for
  * <a href="https://classification.nlm.nih.gov/">National Library of Medicine call numbers</a>.
  * This class uses the same logic for computing sort keys as {@link LCCallNumber}
- * but it has changed {@link #isValid()} method. NLM call numbers utilize schedules QS-QZ and W and WA-WZ.
+ * but it has changed {@link #isValid()} method. NLM call numbers utilize schedules
+ * QS-QZ and W and WA-WZ, for 19th Century also QSA-QZZ and WAA-WZZ schedule.
  */
 public class NlmCallNumber extends LCCallNumber {
 
@@ -30,12 +31,12 @@ public class NlmCallNumber extends LCCallNumber {
 
   @Override
   public boolean isValid() {
-    if (this.classLetters == null || this.classLetters.length() > 2 || this.classDigits == null) {
+    if (this.classLetters == null || this.classLetters.length() > 3 || this.classDigits == null) {
       return false;
     }
     if (this.classLetters.startsWith("W")) {
       return true;
     }
-    return this.classLetters.compareTo("QS") >= 0 && this.classLetters.compareTo("QZ") <= 0;
+    return this.classLetters.compareTo("QS") >= 0 && this.classLetters.compareTo("QZZ") <= 0;
   }
 }

--- a/test/src/org/marc4j/callnum/NlmCallNumberTest.java
+++ b/test/src/org/marc4j/callnum/NlmCallNumberTest.java
@@ -17,34 +17,40 @@ public class NlmCallNumberTest {
     "QS 124 B811m 1875",
     "QT 104 B736 2003",
     "QT 104 B736 2009",
+    "W 26.55.S6",
     "WA 102.5 B5315 2018",
     "WA 102.5 B62 2018",
     "WB 102.5 B62 2018",
     "WC 250 M56 2011",
-    "WC 250 M6 2011"
+    "WZ 250 M6 2011"
   );
 
   private static final List<String> invalidNlmNumbers = Arrays.asList(
+    "AA 11 .GA1 E53 2005",
+    "Q 11 .GA1 E53 2005",
     "QA 11 .GA1 E53 2005",
     "QB 11 .GA1 F875d 1999",
     "QC 11 .GA1 Q6 2012",
     "QD 11 .GI8 P235s 2006",
     "QG 124 B811m 1875",
-    "W 250 M56 2011",
+    "QR 11 .GA1 E53 2005",
+    "QSS 11 .GA1 E53 2005",
+    "WAA 102.5 B5315 2018",
+    "WZZ 250 M6 2011",
     "Z 250 M6 2011"
   );
 
   @Test
   public void isValidNlmNumber() {
     for (String validNlmNumber : validNlmNumbers) {
-      assertTrue(new NlmCallNumber(validNlmNumber).isValid());
+      assertTrue(validNlmNumber, new NlmCallNumber(validNlmNumber).isValid());
     }
   }
 
   @Test
   public void isInvalidNlmNumber() {
-    for (String validNlmNumber : invalidNlmNumbers) {
-      assertFalse(new NlmCallNumber(validNlmNumber).isValid());
+    for (String invalidNlmNumber : invalidNlmNumbers) {
+      assertFalse(invalidNlmNumber, new NlmCallNumber(invalidNlmNumber).isValid());
     }
   }
 

--- a/test/src/org/marc4j/callnum/NlmCallNumberTest.java
+++ b/test/src/org/marc4j/callnum/NlmCallNumberTest.java
@@ -11,32 +11,39 @@ public class NlmCallNumberTest {
 
   private static final List<String> validNlmNumbers = Arrays.asList(
     "QS 11 .GA1 E53 2005",
+    "QSA 11 .GA1 E53 2005",
     "QS 11 .GA1 F875d 1999",
     "QS 11 .GA1 Q6 2012",
     "QS 11 .GI8 P235s 2006",
     "QS 124 B811m 1875",
     "QT 104 B736 2003",
     "QT 104 B736 2009",
+    "QZ 104 B736 2009",
+    "QZZ 104 B736 2009",
     "W 26.55.S6",
     "WA 102.5 B5315 2018",
+    "WAA 102.5 B5315 2018",
     "WA 102.5 B62 2018",
     "WB 102.5 B62 2018",
     "WC 250 M56 2011",
-    "WZ 250 M6 2011"
+    "WZ 250 M6 2011",
+    "WZZ 250 M6 2011"
   );
 
   private static final List<String> invalidNlmNumbers = Arrays.asList(
     "AA 11 .GA1 E53 2005",
     "Q 11 .GA1 E53 2005",
     "QA 11 .GA1 E53 2005",
+    "QAAA 11 .GA1 E53 2005",
     "QB 11 .GA1 F875d 1999",
     "QC 11 .GA1 Q6 2012",
     "QD 11 .GI8 P235s 2006",
     "QG 124 B811m 1875",
     "QR 11 .GA1 E53 2005",
-    "QSS 11 .GA1 E53 2005",
-    "WAA 102.5 B5315 2018",
-    "WZZ 250 M6 2011",
+    "QSAA 11 .GA1 E53 2005",
+    "QZZZ 11 .GA1 E53 2005",
+    "WAAA 102.5 B5315 2018",
+    "WZZZ 250 M6 2011",
     "Z 250 M6 2011"
   );
 


### PR DESCRIPTION
https://classification.nlm.nih.gov/outline
has these classification schedules: QS-QZ and W and WA-WZ, for 19th Century also QSA-QZZ and WAA-WZZ.

The current marc4j implementation incorrectly rejects W, and it incorrectly accepts classification schedules longer than three letters.

NlmCallNumberTest.java should be moved into the test/src directory.