### PR TITLE
Linked field check no longer fails due to occurrence

### DIFF
--- a/src/org/marc4j/marc/impl/RecordImpl.java
+++ b/src/org/marc4j/marc/impl/RecordImpl.java
@@ -205,7 +205,7 @@ public class RecordImpl implements Record {
         if (tag.startsWith("LNK") && field.getTag().equals("880")) {
             final DataField df = (DataField) field;
             final Subfield link = df.getSubfield('6');
-            if (link != null && link.getData().equals(tag.substring(3))) {
+            if (link != null && link.getData().startsWith(tag.substring(3))) {
                 return true;
             }
         }


### PR DESCRIPTION
When checking if a field is linked (via $6) the previous exact match would fail due to the lack of allowance for the occurrence number (e.g. 264$6 = "880-02" and 880$6 = "264-02") at the end of the string.
Ref:
https://www.loc.gov/marc/bibliographic/ecbdcntf.html (see $6 - Linkage)
https://www.loc.gov/marc/bibliographic/bd880.html