### PR TITLE
Linked field no longer fails due to occurrence

### DIFF
--- a/src/org/marc4j/marc/impl/RecordImpl.java
+++ b/src/org/marc4j/marc/impl/RecordImpl.java
@@ -205,7 +205,7 @@ public class RecordImpl implements Record {
         if (tag.startsWith("LNK") && field.getTag().equals("880")) {
             final DataField df = (DataField) field;
             final Subfield link = df.getSubfield('6');
-            if (link != null && link.getData().equals(tag.substring(3))) {
+            if (link != null && link.getData().substring(0, 3).equals(tag.substring(3))) {
                 return true;
             }
         }

--- a/test/resources/azdoud.xml
+++ b/test/resources/azdoud.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<collection xmlns="http://www.loc.gov/MARC21/slim">
+  <record xmlns:marc="http://www.loc.gov/MARC21/slim">
+    <leader>03438cam a2200577 i 4500</leader>
+    <controlfield tag="001">in00006816706</controlfield>
+    <controlfield tag="005">20240229122825.0</controlfield>
+    <controlfield tag="008">240213s2022    mr       b    001 0 fre d</controlfield>
+    <datafield ind1=" " ind2=" " tag="020">
+      <subfield code="a">9789920739788</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="020">
+      <subfield code="a">9920739782</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">(OCoLC)on1420910598</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">(OCoLC)1420910598</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="040">
+      <subfield code="a">EEM</subfield>
+      <subfield code="b">eng</subfield>
+      <subfield code="e">rda</subfield>
+      <subfield code="c">EEM</subfield>
+      <subfield code="d">EEM</subfield>
+      <subfield code="d">UtOrBLW</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="041">
+      <subfield code="a">fre</subfield>
+      <subfield code="a">ber</subfield>
+      <subfield code="b">ber</subfield>
+      <subfield code="b">fre</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="100">
+      <subfield code="a">Azdoud, Driss,</subfield>
+      <subfield code="e">author.</subfield>
+      <subfield code="0">http://id.loc.gov/authorities/names/no2011183558</subfield>
+    </datafield>
+    <datafield ind1="1" ind2="0" tag="245">
+      <subfield code="6">880-01</subfield>
+      <subfield code="a">Choix de proverbs amazighes /</subfield>
+      <subfield code="c">Driss Azdoud = Timstiyin n wanziw n tmazig̳t / Aẓḍuḍ Dris.</subfield>
+    </datafield>
+    <datafield ind1="3" ind2="1" tag="246">
+      <subfield code="6">880-02</subfield>
+      <subfield code="a">Timstiyin n wanziw n tmazig̳t</subfield>
+    </datafield>
+    <datafield ind1="3" ind2=" " tag="246">
+      <subfield code="a">Timstiyin n wanziw n tmaziɣt</subfield>
+    </datafield>
+    <datafield ind1="1" ind2="4" tag="246">
+      <subfield code="6">880-03</subfield>
+      <subfield code="a">Tadla n wanziwn imazig̳n =</subfield>
+      <subfield code="b">Choix de proverbs amazighes</subfield>
+    </datafield>
+    <datafield ind1="3" ind2=" " tag="246">
+      <subfield code="a">Tadla n wanziwn imaziɣn</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="1" tag="264">
+      <subfield code="a">[Morocco] :</subfield>
+      <subfield code="b">Institut Royal de la Culture Amazighe,</subfield>
+      <subfield code="c">[2022]</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="3" tag="264">
+      <subfield code="a">Rabat :</subfield>
+      <subfield code="b">Editions &amp; Impressions Bouregreg</subfield>
+    </datafield>
+    <datafield ind1="1" ind2="0" tag="880">
+      <subfield code="6">245-01</subfield>
+      <subfield code="a">Choix de proverbs amazighes /</subfield>
+      <subfield code="c">Driss Azdoud = ⵜⵉⵎⵙⵜⵉⵢⵉⵏ ⵏ ⵡⴰⵏⵣⵉⵡ ⵏ ⵜⵎⴰⵣⵉⵖⵜ / ⴰⵥⴹⵓⴹ ⴷⵔⵉⵙ.</subfield>
+    </datafield>
+    <datafield ind1="3" ind2="1" tag="880">
+      <subfield code="6">246-02</subfield>
+      <subfield code="a">ⵜⵉⵎⵙⵜⵉⵢⵉⵏ ⵏ ⵡⴰⵏⵣⵉⵡ ⵏ ⵜⵎⴰⵣⵉⵖⵜ</subfield>
+    </datafield>
+    <datafield ind1="1" ind2="4" tag="880">
+      <subfield code="6">246-03</subfield>
+      <subfield code="a">ⵜⴰⴷⵍⴰ ⵏ ⵡⴰⵏⵣⵉⵡⵏ ⵉⵎⴰⵣⵉⵖⵏ =</subfield>
+      <subfield code="b">Choix de proverbs amazighes</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="994">
+      <subfield code="a">C0</subfield>
+      <subfield code="b">EEM</subfield>
+    </datafield>
+  </record>
+</collection>

--- a/test/src/org/marc4j/test/MarcXmlReaderTest.java
+++ b/test/src/org/marc4j/test/MarcXmlReaderTest.java
@@ -46,6 +46,22 @@ public class MarcXmlReaderTest {
         input.close();
     }
 
+    @Test
+    public void testMarcXmlReaderLinkedFields() throws Exception {
+        final InputStream input = getClass().getResourceAsStream("/azdoud.xml");
+        assertNotNull(input);
+        final MarcXmlReader reader = new MarcXmlReader(input);
+
+        assertTrue("Should have at least one record", reader.hasNext());
+
+        final Record record1 = reader.next();
+        TestUtils.validateAzdoudRecord(record1);
+        TestUtils.validateAzdoudLinkedFields(record1);
+
+        assertFalse(" has more than one records", reader.hasNext());
+        input.close();
+    }
+
     /**
      * Tests reading record type from MARCXML record.
      */

--- a/test/src/org/marc4j/test/utils/StaticTestRecords.java
+++ b/test/src/org/marc4j/test/utils/StaticTestRecords.java
@@ -23,6 +23,7 @@ public class StaticTestRecords {
     public static final String RESOURCES_BRKRTEST_UTF8_MRC = "/brkrtest_UTF8.mrc";
     public static final String RESOURCES_CHABON_MRC = "/chabon.mrc";
     public static final String RESOURCES_CHABON_XML = "/chabon.xml";
+    public static final String RESOURCES_AZDOUD_XML = "/azdoud.xml";
     public static final String RESOURCES_OCLC814388508_XML = "/OCLC_814388508.xml";    
     public static final String RESOURCES_CYRILLIC_CAPITAL_E_MRC = "/cyrillic_capital_e.mrc";
     public static final String RESOURCES_GREEK_MISSING_CHARSET_MRC = "/greekmissingcharsetchange.mrc";
@@ -104,7 +105,6 @@ public class StaticTestRecords {
         sumland.addVariableField(factory.newDataField("650", ' ', '1', "a", "Magic", "v", "Fiction."));
         return sumland;
     }
-
 
     public static Record getSummerlandRecord() {
         return makeSummerlandRecord();

--- a/test/src/org/marc4j/test/utils/TestUtils.java
+++ b/test/src/org/marc4j/test/utils/TestUtils.java
@@ -62,6 +62,59 @@ public class TestUtils {
         assertFalse("too many fields", it.hasNext());
     }
 
+    public static void validateAzdoudRecord(Record record) {
+        assertEquals("leader", "03438cam a2200577 i 4500", record.getLeader().marshal());
+        Iterator<VariableField> it = record.getVariableFields().iterator();
+        assertControlFieldInRecordEquals("001", "in00006816706", it.next());
+        assertControlFieldInRecordEquals("005", "20240229122825.0", it.next());
+        assertControlFieldInRecordEquals("008", "240213s2022    mr       b    001 0 fre d", it.next());
+        assertDataFieldEquals(it.next(), "020", ' ', ' ', "a", "9789920739788");
+        assertDataFieldEquals(it.next(), "020", ' ', ' ', "a", "9920739782");
+        assertDataFieldEquals(it.next(), "035", ' ', ' ', "a", "(OCoLC)on1420910598");
+        assertDataFieldEquals(it.next(), "035", ' ', ' ', "a", "(OCoLC)1420910598");
+        assertDataFieldEquals(it.next(), "040", ' ', ' ', "a", "EEM", "b", "eng", "e", "rda", "c", "EEM", "d", "EEM", "d", "UtOrBLW");
+        assertDataFieldEquals(it.next(), "041", '1', ' ', "a", "fre", "a", "ber", "b", "ber", "b", "fre");
+        assertDataFieldEquals(it.next(), "100", '1', ' ', "a", "Azdoud, Driss,", "e", "author.", "0", "http://id.loc.gov/authorities/names/no2011183558");
+        assertDataFieldEquals(it.next(), "245", '1', '0', "6", "880-01", "a", "Choix de proverbs amazighes /", "c", "Driss Azdoud = Timstiyin n wanziw n tmazig̳t / Aẓḍuḍ Dris.");
+        assertDataFieldEquals(it.next(), "246", '3', '1', "6", "880-02", "a", "Timstiyin n wanziw n tmazig̳t");
+        assertDataFieldEquals(it.next(), "246", '3', ' ', "a", "Timstiyin n wanziw n tmaziɣt");
+        assertDataFieldEquals(it.next(), "246", '1', '4', "6", "880-03", "a", "Tadla n wanziwn imazig̳n =", "b", "Choix de proverbs amazighes");
+        assertDataFieldEquals(it.next(), "246", '3', ' ', "a", "Tadla n wanziwn imaziɣn");
+        assertDataFieldEquals(it.next(), "264", ' ', '1', "a", "[Morocco] :", "b", "Institut Royal de la Culture Amazighe,", "c", "[2022]");
+        assertDataFieldEquals(it.next(), "264", ' ', '3', "a", "Rabat :", "b", "Editions & Impressions Bouregreg");
+        assertDataFieldEquals(it.next(), "880", '1', '0', "6", "245-01", "a", "Choix de proverbs amazighes /", "c", "Driss Azdoud = ⵜⵉⵎⵙⵜⵉⵢⵉⵏ ⵏ ⵡⴰⵏⵣⵉⵡ ⵏ ⵜⵎⴰⵣⵉⵖⵜ / ⴰⵥⴹⵓⴹ ⴷⵔⵉⵙ.");
+        assertDataFieldEquals(it.next(), "880", '3', '1', "6", "246-02", "a", "ⵜⵉⵎⵙⵜⵉⵢⵉⵏ ⵏ ⵡⴰⵏⵣⵉⵡ ⵏ ⵜⵎⴰⵣⵉⵖⵜ");
+        assertDataFieldEquals(it.next(), "880", '1', '4', "6", "246-03", "a", "ⵜⴰⴷⵍⴰ ⵏ ⵡⴰⵏⵣⵉⵡⵏ ⵉⵎⴰⵣⵉⵖⵏ =", "b", "Choix de proverbs amazighes");
+        assertDataFieldEquals(it.next(), "994", ' ', ' ', "a", "C0", "b", "EEM");
+        assertFalse("too many fields", it.hasNext());
+    }
+
+    public static void validateAzdoudLinkedFields(Record record) {
+        DataField f245 = (DataField) record.getVariableField("245");
+        assertNotNull(f245);
+        assertEquals(3, f245.getSubfields().size());
+        assertEquals("Choix de proverbs amazighes /", f245.getSubfield('a').getData());
+
+        DataField kf245 = (DataField) record.getVariableField("LNK245");
+        assertNotNull(kf245);
+        assertEquals(3, kf245.getSubfields().size());
+        assertEquals("245-01", kf245.getSubfield('6').getData());
+
+        List<VariableField> lkf246 = record.getVariableFields("LNK246");
+        assertNotNull(lkf246);
+        assertEquals(2, lkf246.size());
+
+        DataField kf246_02 = (DataField) lkf246.get(0);
+        assertEquals(2, kf246_02.getSubfields().size());
+        assertEquals("246-02", kf246_02.getSubfield('6').getData());
+        assertEquals("ⵜⵉⵎⵙⵜⵉⵢⵉⵏ ⵏ ⵡⴰⵏⵣⵉⵡ ⵏ ⵜⵎⴰⵣⵉⵖⵜ", kf246_02.getSubfield('a').getData());
+        DataField kf246_03 = (DataField) lkf246.get(1);
+        assertEquals(3, kf246_03.getSubfields().size());
+        assertEquals("246-03", kf246_03.getSubfield('6').getData());
+        assertEquals("ⵜⴰⴷⵍⴰ ⵏ ⵡⴰⵏⵣⵉⵡⵏ ⵉⵎⴰⵣⵉⵖⵏ =", kf246_03.getSubfield('a').getData());
+        assertEquals("Choix de proverbs amazighes", kf246_03.getSubfield('b').getData());
+    }
+
     public static void validateFreewheelingBobDylanRecord(Record record) {
         assertEquals("leader", "01471cjm a2200349 a 4500", record.getLeader().marshal());
         Iterator<VariableField> it = record.getVariableFields().iterator();


### PR DESCRIPTION
When checking if a field is linked (via $6) the previous logic would fail due to an equals match checking without excluding the occurrence number at the end of the string.

Added related unit tests for LNK usage.

Ref:
https://www.loc.gov/marc/bibliographic/ecbdcntf.html (see $6 - Linkage)
https://www.loc.gov/marc/bibliographic/bd880.html