### PR TITLE
Fix license in pom.xml

### DIFF
--- a/pom_template.xml
+++ b/pom_template.xml
@@ -12,8 +12,8 @@
 
   <licenses>
     <license>
-      <name>GNU Lesser General Public License, Version 2.1</name>
-      <url>http://www.gnu.org/licenses/lgpl-2.1.html</url>
+      <name>LGPL-2.1-or-later</name>
+      <url>https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html</url>
       <comments>Licensed under the GNU LGPL 2.1 or later (at your option)</comments>
     </license>
   </licenses>


### PR DESCRIPTION
https://maven.apache.org/pom.html#Licenses says:

> Using an SPDX identifier as the license name is recommended.

The correct SPDX identifier is LGPL-2.1-or-later:
https://spdx.org/licenses/

Using an SPDX identifier avoids manual checks and allows compliance tools to do a fully automated license check.

http://www.gnu.org/licenses/lgpl-2.1.html responds with 302, the correct URL is https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html