### PR TITLE
Creating Sonatype compatible package

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -250,7 +250,6 @@
             </manifest>
             <fileset dir="${apidoc.dir}">
                 <include name="**" />
-
             </fileset>
         </jar>
 
@@ -274,7 +273,6 @@
                 <include name="**/*.java" />
             </fileset>
         </jar>
-
         <property name="dist.already.run" value="true" />
     </target>
 

--- a/build.xml
+++ b/build.xml
@@ -250,8 +250,10 @@
             </manifest>
             <fileset dir="${apidoc.dir}">
                 <include name="**" />
+
             </fileset>
         </jar>
+
         <jar jarfile="${dist.dir}/${jar.sources.name}" >
             <manifest>
                 <section name="org/marc4j">
@@ -272,7 +274,46 @@
                 <include name="**/*.java" />
             </fileset>
         </jar>
+
         <property name="dist.already.run" value="true" />
+    </target>
+
+    <target name="sonatype-package" description="Creates the uploadable Sonatype package" depends="dist" unless="sonatype-package.already.run">
+        <echo message="Generate sha1 files" />
+        <checksum algorithm="SHA-256" fileext=".sha1" format="MD5SUM" todir="${dist.dir}">
+            <fileset dir="${dist.dir}">
+                <include name="marc4j*.jar" />
+                <include name="marc4j*.pom" />
+            </fileset>
+        </checksum>
+
+        <echo message="Generate md5 files" />
+        <checksum fileext=".md5" todir="${dist.dir}">
+            <fileset dir="${dist.dir}">
+                <include name="marc4j*.jar" />
+                <include name="marc4j*.pom" />
+            </fileset>
+        </checksum>
+
+        <echo message="Generate asc files" />
+        <checksum algorithm="SHA-512" fileext=".asc" todir="${dist.dir}">
+            <fileset dir="${dist.dir}">
+                <include name="marc4j*.jar" />
+                <include name="marc4j*.pom" />
+            </fileset>
+        </checksum>
+
+        <echo message="Generate bundle file for Sonatype" />
+        <zip destfile="${dist.dir}/central-bundle.zip" >
+            <zipfileset prefix="org/marc4j/${versionstr}" dir="${dist.dir}">
+                <include name="marc4j*.jar"/>
+                <include name="marc4j*.pom"/>
+                <include name="marc4j*.sha1"/>
+                <include name="marc4j*.asc"/>
+                <include name="marc4j*.md5"/>
+            </zipfileset>
+        </zip>
+        <property name="sonatype-package.already.run" value="true" />
     </target>
 
     <target name="sign" depends="dist,release-ready" if="release.is.ready" unless="is.snapshot" >

--- a/build.xml
+++ b/build.xml
@@ -252,7 +252,6 @@
                 <include name="**" />
             </fileset>
         </jar>
-
         <jar jarfile="${dist.dir}/${jar.sources.name}" >
             <manifest>
                 <section name="org/marc4j">


### PR DESCRIPTION
This pull request intended to help the adaption to the new Sonatype requirements. It creates new Ant target: `sonatype-package`, that creates a package file (`central-bundle.zip`), that fits to https://central.sonatype.org/publish/publish-portal-upload/. Usage is simple:

```
ant sonatype-package
```

It does not upload the file, it only creates it. As I do not have right to upload the file even manually, I am not sure that it will be accepted without any modification, however I hope it helps in the process.

See more: #110 